### PR TITLE
build: clean up pyproject.toml dependencies and align target Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -62,22 +61,9 @@ dependencies = [
     "psutil",
     "aiohttp",
     "litprinter",
-    "lxml>=5.2.2",
     "pydantic",
-    "fastapi>=0.128.0",
-    "uvicorn>=0.40.0",
-    "starlette>=0.50.0",
     "openai>=2.43.0",
-    "pytest>=9.0.2",
-    "tiktoken>=0.7.0",
-    "tokenizers>=0.23.1",
-    "safetensors>=0.8.0",
-    "huggingface-hub>=1.20.1",
     "requests>=2.32.5",
-    "mkdocs>=1.6.1",
-    "mkdocstrings>=1.0.4",
-    "mkdocstrings-python>=2.0.5",
-    "mkdocs-material>=9.7.6",
 ]
 
 [project.scripts]
@@ -94,28 +80,40 @@ YouTube = "https://youtube.com/@OEvortex"
 [project.optional-dependencies]
 dev = [
     "ruff>=0.1.6",
-    "pytest>=7.4.2",
+    "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
+    "mypy>=1.10.0",
+    "vulture>=2.16",
+    "numpy>=2.2.0",
 ]
 api = [
-    "fastapi",
-    "uvicorn[standard]",
+    "fastapi>=0.128.0",
+    "uvicorn[standard]>=0.40.0",
+    "starlette>=0.50.0",
     "pydantic",
     "python-multipart",
-    "tiktoken",  # Added tiktoken for token counting support
-    "jinja2",  # Template engine for custom Swagger UI
+    "tiktoken>=0.7.0",
+    "jinja2",
     "websockets>=11.0",
-    "starlette",
-    "regex"
+    "regex",
+]
+models = [
+    "tiktoken>=0.7.0",
+    "tokenizers>=0.23.1",
+    "safetensors>=0.8.0",
+    "huggingface-hub>=1.20.1",
 ]
 parser = [
-    "lxml>=5.2.2",  # Optional: faster HTML/XML parsing with lxml
+    "lxml>=5.2.2",
 ]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
     "mkdocstrings>=1.0.4",
     "mkdocstrings-python>=2.0.5",
+]
+all = [
+    "llm4free[api,models,parser,docs,dev]",
 ]
 
 [tool.pytest.ini_options]
@@ -161,7 +159,7 @@ version = {attr = "llm4free.version.__version__"}
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]


### PR DESCRIPTION
### Description
This PR streamlines `pyproject.toml` dependencies and resolves version inconsistencies:

- **Trimmed Core Dependencies:** Removed dev (`pytest`), docs (`mkdocs`, `mkdocstrings`), and server (`fastapi`, `uvicorn`, `starlette`) packages from mandatory installation requirements to ensure a lightweight base footprint.
- **Organized Optional Dependencies:** Partitioned optional dependencies into `[project.optional-dependencies]` (`dev`, `api`, `models`, `parser`, `docs`, `all`).
- **Python Version Alignment:** Removed the `Python :: 3.9` classifier and updated `[tool.ruff] target-version` to `py310` to match `requires-python = ">=3.10"`.

### Testing
- Verified in isolated Python virtual environment with `uv`.
- Successfully ran full pytest suite (`pytest -v`).
